### PR TITLE
Fix issue where the socket doesn't get forgotten and causes 100% load.

### DIFF
--- a/gbulb/transports.py
+++ b/gbulb/transports.py
@@ -72,7 +72,7 @@ class BaseTransport(transports.BaseTransport):
             self._protocol.connection_lost(exc)
         finally:
             if self._sock is not None:
-                self._sock.close()
+                self._sock.detach()
                 self._sock = None
             if self._server is not None:
                 self._server._detach()


### PR DESCRIPTION
This was a specific bug where the socket (a client connection in this case) wasn't being 'forgotten' and caused 100% cpu load. Using detach seems to cause the socket to be 'forgotten' as part of the main thread that in a 'server' style usage will still be running.